### PR TITLE
Refactor tokenizer pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Elasticsearch-ish inverse indexed search engine for Node.",
   "main": "lib/index.js",
   "repository": "git@github.com:10eTechnology/esjs.git",

--- a/src/charRegex.js
+++ b/src/charRegex.js
@@ -1,0 +1,4 @@
+const charRegex =
+  "[\u2000-\u206F\u2E00-\u2E7F'!\"#$%&()*+,-./:;<=>?@\\[\\]^_`{|}~]";
+
+export default charRegex;

--- a/src/index.js
+++ b/src/index.js
@@ -101,19 +101,31 @@ export default class ESjs {
     this.addTerms(doc, field);
   }
 
+  pipesForTokens() {
+    const pipes = ['whitespace', 'strip', 'tokenize', 'stopwords', 'stemmer'];
+
+    // eventually could be more elaborate based on configuration
+    return pipes.filter(pipe => this.stopwords || pipe !== 'stopwords');
+  }
+
   addTokens(doc, field) {
-    const pipe = this.stopwords ? 'run' : 'runWithoutStopwords';
-    const tokens = Pipeline[pipe](doc[field]);
+    const pipes = this.pipesForTokens(field);
+    const tokens = Pipeline.run(doc[field], pipes);
 
     this.updateDocFieldLength(doc, field, tokens.length);
     this.addTokensWithCounts(doc, field, tokens);
   }
 
+  pipesForTerms() {
+    const pipes = ['whitespace', 'strip', 'stopwords'];
+
+    // eventually could be more elaborate based on configuration
+    return pipes.filter(pipe => this.stopwords || pipe !== 'stopwords');
+  }
+
   addTerms(doc, field) {
-    const pipe = this.stopwords ? 'tokenize' : 'tokenizeWithoutStopwords';
-    const tokens = Pipeline[pipe](doc[field], {
-      stopwords: this.stopwords,
-    });
+    const pipes = this.pipesForTerms(field);
+    const tokens = Pipeline.run(doc[field], pipes);
 
     this.addTokensWithCounts(doc, field, tokens, 'raw');
   }

--- a/src/stemmers/PorterStemmer.js
+++ b/src/stemmers/PorterStemmer.js
@@ -1,7 +1,7 @@
 import { stemmer } from 'porter-stemmer';
 
 const PorterStemmer = {
-  run: words => words.map(w => stemmer(w)),
+  run: input => input.map(w => stemmer(w)),
 };
 
 export default PorterStemmer;

--- a/src/tokenizers/StandardTokenizer.js
+++ b/src/tokenizers/StandardTokenizer.js
@@ -1,20 +1,17 @@
-const regexp =
-  /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,-./:;<=>?@[\]^_`{|}~]/g;
+import charRegex from '../charRegex';
+
+const reTokens = new RegExp(charRegex, 'g');
 
 const StandardTokenizer = {
-  run: (input) => {
-    const tokens = [];
-
-    if (!input) {
-      return tokens;
-    }
-
-    return input
-      .replace(regexp, ' ')
+  run: input => input.reduce((tokens, word) => {
+    const clean = word
+      .replace(reTokens, ' ')
       .toLowerCase()
       .split(/\s+/)
-      .filter(t => t !== '');
-  },
+      .filter(t => !!t);
+
+    return (clean.length > 0) ? tokens.concat(clean) : tokens;
+  }, []),
 };
 
 export default StandardTokenizer;

--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -11,9 +11,10 @@ const fields = {
 };
 
 const docs = [{
-  id:    1,
-  title: 'title',
-  body:  'body',
+  id:       1,
+  title:    'title',
+  body:     'body',
+  category: 'category',
 }];
 
 const searchDocs = [{
@@ -30,7 +31,7 @@ const searchDocs = [{
   id:       3,
   title:    'Tickets on sale for festival on the Boardwalk this weekend',
   body:     'Popular music and delicious food to be enjoyed by all.',
-  category: 'events',
+  category: 'live_events',
 }, {
   id:       4,
   title:    'Special: I got out of jail for free!',
@@ -62,7 +63,6 @@ function storeDocs(config) {
 function searchIds(results) {
   return results.map(result => result.id);
 }
-
 
 describe('.new()', () => {
   context('given an index configuration', () => {
@@ -296,7 +296,7 @@ describe('.search()', () => {
   });
 
   context('given a query with filters', () => {
-    describe('given a single filter', () => {
+    context('given a single filter', () => {
       const results = idx.search({
         must: {
           match: { _all: 'weekend' },
@@ -313,7 +313,24 @@ describe('.search()', () => {
       });
     });
 
-    describe('given an array of filters', () => {
+    context('given a term with an underscore', () => {
+      const results = idx.search({
+        must: {
+          match: { _all: 'popular' },
+        },
+        filter: {
+          term: {
+            category: 'live_events',
+          },
+        },
+      });
+
+      it('returns the expected results', () => {
+        expect(searchIds(results)).to.eql([3]);
+      });
+    });
+
+    context('given an array of filters', () => {
       const results = idx.search({
         must: {
           match: { _all: 'weekend' },

--- a/test/lib/pipeline.spec.js
+++ b/test/lib/pipeline.spec.js
@@ -4,14 +4,84 @@ import expect from 'expect.js';
 import Pipeline from '../../src/pipeline';
 
 describe('Pipeline', () => {
-  const input = 'The greatest show on Earth running!';
+  const input = 'This is a_string with $# white&space etc, running';
 
-  it('produces the expected output', () => {
-    expect(Pipeline.run(input)).to.eql([
-      'greatest',
-      'show',
-      'earth',
-      'run',
-    ]);
+  describe('whitespace', () => {
+    const pipes = ['whitespace'];
+
+    it('splits on whitespace', () => {
+      expect(Pipeline.run(input, pipes)).to.eql([
+        'This',
+        'is',
+        'a_string',
+        'with',
+        '$#',
+        'white&space',
+        'etc,',
+        'running',
+      ]);
+    });
+  });
+
+  describe('strip', () => {
+    const pipes = ['whitespace', 'strip'];
+
+    it('removes disallowed characters from the ends of words', () => {
+      expect(Pipeline.run(input, pipes)).to.eql([
+        'This',
+        'is',
+        'a_string',
+        'with',
+        'white&space',
+        'etc',
+        'running',
+      ]);
+    });
+  });
+
+  describe('tokenize', () => {
+    const pipes = ['whitespace', 'strip', 'tokenize'];
+
+    it('tokenizes the strings', () => {
+      expect(Pipeline.run(input, pipes)).to.eql([
+        'this',
+        'is',
+        'a',
+        'string',
+        'with',
+        'white',
+        'space',
+        'etc',
+        'running',
+      ]);
+    });
+  });
+
+  describe('stopwords', () => {
+    const pipes = [
+      'whitespace', 'strip', 'tokenize', 'stopwords',
+    ];
+
+    it('removes stopwords', () => {
+      expect(Pipeline.run(input, pipes)).to.eql([
+        'string',
+        'white',
+        'space',
+        'running',
+      ]);
+    });
+  });
+
+  describe('stemmer', () => {
+    const pipes = ['whitespace', 'strip', 'tokenize', 'stopwords', 'stemmer'];
+
+    it('stems the strings', () => {
+      expect(Pipeline.run(input, pipes)).to.eql([
+        'string',
+        'white',
+        'space',
+        'run',
+      ]);
+    });
   });
 });

--- a/test/lib/tokenizers.spec.js
+++ b/test/lib/tokenizers.spec.js
@@ -4,7 +4,9 @@ import expect from 'expect.js';
 import { StandardTokenizer, tokenCount } from '../../src/tokenizers';
 
 describe('StandardTokenizer', () => {
-  const input = 'This.String. has#much punctions! They \'should\' be "removed"';
+  const input =
+    'This.String. has#much punctions! They \'should\' be "removed"'
+      .split(/\s+/);
 
   it('produces the expected output', () => {
     expect(StandardTokenizer.run(input)).to.eql([


### PR DESCRIPTION
The first iteration of the tokenizer pipeline was pretty brittle and did
not allow for easy configuration.

A side effect was that raw tokens still got split on non-word
characters, which meant you couldn't do term filtering on strings like
'live_events', as that string would be tokenized as 'live', 'events'.

This PR refactors the pipeline to make it easy to pick and choose which
operations to apply in the pipeline, allowing for the term indexing to
skip tokenization while keeping the whitespace splitter and general
string cleanup.