### PR TITLE
Test indexing issue

### DIFF
--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -255,6 +255,7 @@ describe('.search()', () => {
   });
 
   context('given a document update', () => {
+    // document 4 should no longer match on 'weekend' post-update
     idx.addDoc({
       id:       4,
       title:    'Special: I got out of jail for free!',

--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -254,6 +254,25 @@ describe('.search()', () => {
     });
   });
 
+  context('given a document update', () => {
+    idx.addDoc({
+      id:       4,
+      title:    'Special: I got out of jail for free!',
+      body:     'You wouldn\'t believe the new regulations.',
+      category: 'crime',
+    });
+
+    const results = idx.search({
+      must: {
+        match: { _all: 'weekend' },
+      },
+    });
+
+    it('should no longer return the updated document', () => {
+      expect(searchIds(results)).to.eql([3]);
+    });
+  });
+
   context('given a query that changes boosting', () => {
     const results = idx.search({
       must: {


### PR DESCRIPTION
#### Comments
* Adds a simple test case to highlight an issue with document indexing. 
* On a document update, the old document should be purged from the index before re-indexing.

> "When you delete a document, theres a bitmap that marks the document as deleted, and Lucene will filter it out for every subsequent search, but the segment itself doesn’t change. So an update, for example, is essentially a delete followed by a re-index." - Alex Brasetvik, ElasticSearch
