### PR TITLE
Add field 'analyzer' config + add `standard` and `keyword` analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ const fields = {
   name:        { boost: 2 },
   description: { boost: 1 },
   job:         null,
+  status:      { analyzer: 'keyword' },
 };
 
 const idx = new ESjs({ fields });
@@ -29,6 +30,7 @@ idx.addDoc({
   name: 'Larry Jones',
   description: 'A nice guy',
   job: 'plumber',
+  status: 'AVAILABLE',
 });
 
 idx.addDoc({
@@ -36,6 +38,7 @@ idx.addDoc({
   name: 'Moe Jones',
   description: "Larry's brother, a decent guy",
   job: 'architect',
+  status: 'AVAILABLE',
 });
 
 idx.addDoc({
@@ -43,6 +46,7 @@ idx.addDoc({
   name: 'Curly Jones',
   description: "Moe's brother, a funny guy",
   job: 'mathematician',
+  status: 'UNAVAILABLE',
 });
 
 idx.search('Larry');
@@ -77,6 +81,19 @@ idx.search({
     term: { job: 'plumber' }
   }],
 });
+// []
+idx.search({
+  must: {
+    match: {
+      name: 'Jones',
+    },
+  },
+  filter: [{
+    term: { status: 'AVAILABLE' }, 
+  }],
+});
+// [{ id: 1, score: 0.1 }, { id: 2, score: 0.1 }]
+idx.search('AVAILABLE');
 // []
 
 const json = idx.serialize();
@@ -119,3 +136,20 @@ You can turn off stopwords by setting `stopwords: false` in your configuration.
 
 **This is a temporary implementation.  Configuring the tokenizer pipeline
 will improve with time***
+
+## Field analyzer
+
+You may specify a custom `analyzer` per field with the `analyzer` config option.
+```javascript
+const fields = {
+  status: { analyzer: 'keyword' },
+};
+```
+Currently, the only analyzer supported is `keyword` or `standard`. This option defaults to `standard`.
+
+### `standard`
+Default behavior. Field will be searchable through text search or term filters.
+
+### `keyword`
+
+The `keyword` analyzer will *not* index specified field for text searching. The only way to surface results containing a `keyword` field is through the an exact match on a `filter` `term` query configuration.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint": "./node_modules/.bin/eslint ./src ./test",
     "performance": "node ./performance/index.js",
     "reset": "rm -rf ./node_modules yarn.lock; yarn cache clean; yarn install",
-    "test": "mocha --require babel-register ./test/esjs.spec.js ./test/**/*.spec.js"
+    "test": "mocha --require babel-register ./test/esjs.spec.js ./test/**/*.spec.js ./test/**/**/*.spec.js"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/prefer-default-export */
+import normalize from './normalize';
+
+export {
+  normalize,
+};

--- a/src/config/normalize.js
+++ b/src/config/normalize.js
@@ -1,0 +1,57 @@
+import Validators from './validators';
+
+export const configValidatorMap = {
+  fields: {
+    validate: Validators.shape({
+      '*': Validators.oneOf([
+        Validators.shape({
+          boost:    Validators.number,
+          analyzer: Validators.oneOf(['keyword', 'standard']),
+        }),
+        null,
+      ]),
+    }),
+    default: {},
+  },
+  storeDocs: {
+    validate: Validators.bool,
+    default:  false,
+  },
+  allowPartial: {
+    validate: Validators.bool,
+    default:  false,
+  },
+  stopwords: {
+    validate: Validators.bool,
+    default:  false,
+  },
+};
+
+/**
+ * Given a config object, return a normalized verison with default
+ * values.
+ * @param {Object} config 
+ * @return {Object} normalized config
+ */
+export default function normalize(config) {
+  return Object.keys(configValidatorMap).reduce((newConfig, configKey) => {
+    let configValue = config[configKey];
+    const validatorMap = configValidatorMap[configKey];
+
+    // Use default value specified in `configValidatorMap`, if exists
+    if (
+      typeof configValue === 'undefined' &&
+      Object.prototype.hasOwnProperty.call(validatorMap, 'default')
+    ) {
+      configValue = validatorMap.default;
+    }
+
+    if (!validatorMap.validate(configValue)) {
+      throw new Error(`Invalid value given for '${configKey}', ${configValue}`);
+    }
+
+    newConfig[configKey] = configValue; // eslint-disable-line no-param-reassign
+
+    return newConfig;
+  }, {});
+}

--- a/src/config/validators/bool.js
+++ b/src/config/validators/bool.js
@@ -1,0 +1,9 @@
+/**
+ * Boolean validator function.
+ * 
+ * @param {*} value 
+ * @return boolean
+ */
+export default function bool(value) {
+  return typeof value === 'boolean';
+}

--- a/src/config/validators/index.js
+++ b/src/config/validators/index.js
@@ -1,0 +1,6 @@
+import oneOf from './oneOf';
+import bool from './bool';
+import shape from './shape';
+import number from './number';
+
+export default { oneOf, bool, shape, number };

--- a/src/config/validators/number.js
+++ b/src/config/validators/number.js
@@ -1,0 +1,9 @@
+/**
+ * Number validator function.
+ * 
+ * @param {*} value 
+ * @return boolean
+ */
+export default function number(value) {
+  return typeof value === 'number';
+}

--- a/src/config/validators/oneOf.js
+++ b/src/config/validators/oneOf.js
@@ -1,0 +1,35 @@
+/**
+ * Given an array of allowable values, return a validator function
+ * which compares given argument against allowable values.
+ * Other validator functions are accepted as options. Validator 
+ * functions have an arity of 1 and should return a boolean value.
+ * 
+ * @param {Array} options 
+ * @return {Function} validator function
+ */
+export default function oneOf(options) {
+  if (!Array.isArray(options)) {
+    throw new Error(
+      `oneOf must be given an array of options. ${typeof options} given`,
+    );
+  }
+
+  /**
+   * Validator function. Compare above options against given value.
+   * Other validator functions are accepted as options.
+   * 
+   * @param {*} value
+   * @return {boolean}
+   */
+  return function validate(value) {
+    return options.some((option) => {
+      // Allow validator functions
+      if (typeof option === 'function') {
+        return option(value);
+      }
+
+      // Otherwise, check strict equality
+      return option === value;
+    });
+  };
+}

--- a/src/config/validators/shape.js
+++ b/src/config/validators/shape.js
@@ -1,0 +1,66 @@
+/**
+ * Given a shape descriptor object [the shape], return a function
+ * which will execute validation validation rules upon each value
+ * of given object. Shape should contain a mapping of object value
+ * to validation function. Validation functions have an arity of 1
+ * and should return a boolean value.
+ * 
+ * e.g.:
+ * ```
+ * shape({
+ *   booleanField: value => typeof value === 'boolean',
+ *   numberField: value => typeof value === 'number',
+ * })
+ * ```
+ * @param {Object} shapeDescriptor 
+ * @return {Function} curried validator function
+ */
+export default function shape(shapeDescriptor) {
+  if (typeof shapeDescriptor !== 'object' || shapeDescriptor === null) {
+    throw new Error(
+      `Shape validator config expected an object. 
+      ${typeof shapeDescriptor} given`,
+    );
+  }
+
+  // Every key must correspond to a validator function
+  Object.keys(shapeDescriptor).forEach((key) => {
+    if (typeof shapeDescriptor[key] !== 'function') {
+      throw new Error(`Invalid validator function given for ${key}`);
+    }
+  });
+
+  /**
+   * Validator function. Compare above option config against given
+   * object.
+   * 
+   * @param {*} value
+   * @return {boolean}
+   */
+  return function validate(value) {
+    // No object given? Fail validation. `shape` MUST be an object.
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+
+    return Object.keys(shapeDescriptor).every((field) => {
+      const validateFn = shapeDescriptor[field];
+
+      // '*' acts as a wildcard, which treats input values as a
+      // string map, rather than a sealed object type. Effectively,
+      // this allows passing in an object with arbitrary keys
+      // whose values should all be of like-type.
+      if (field === '*') {
+        // Call the validation function on every object value
+        return Object.values(value).every(valueItem => validateFn(valueItem));
+      }
+
+      if (!Object.prototype.hasOwnProperty.call(value, field)) {
+        // Ignore nonexistent values
+        return true;
+      }
+
+      return validateFn(value[field]);
+    });
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -107,17 +107,12 @@ export default class ESjs {
       analyzer = this.fields[field].analyzer;
     }
 
-    switch (analyzer) {
-      case 'keyword':
-        this.addTerms(doc, field);
-        break;
-      case 'standard':
-        this.addTokens(doc, field);
-        this.addTerms(doc, field);
-        break;
-      default:
-        throw new Error(`Unsupported analyzer, ${analyzer}`);
-    }
+    const analyzerToIndexOps = {
+      keyword:  [this.addTerms],
+      standard: [this.addTokens, this.addTerms],
+    };
+
+    analyzerToIndexOps[analyzer].forEach(op => op.call(this, doc, field));
   }
 
   pipesForTokens() {

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,18 @@ import Pipeline from './pipeline';
 import Serializer from './serializer';
 import { tokenCount } from './tokenizers';
 import Search from './search';
+import { normalize as normalizeConfig } from './config';
 
 export default class ESjs {
   constructor(config = {}, json = '') {
-    this.fields = config ? config.fields : {};
+    const normalizedConfig = normalizeConfig(config);
+
+    this.fields = normalizedConfig.fields;
     this.docs = {};
     this.index = { tokenized: {}, raw: {} };
-    this.storeDocs = config ? config.storeDocs : false;
-    this.allowPartial = config ? config.allowPartial : false;
-    this.stopwords = config ? config.stopwords : true;
+    this.storeDocs = normalizedConfig.storeDocs;
+    this.allowPartial = normalizedConfig.allowPartial;
+    this.stopwords = normalizedConfig.stopwords;
 
     if (json) {
       this.deserialize(json);

--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,24 @@ export default class ESjs {
     }
 
     this.ensureFieldIndex(field);
-    this.addTokens(doc, field);
-    this.addTerms(doc, field);
+
+    let analyzer = 'standard';
+
+    if (this.fields[field] && this.fields[field].analyzer) {
+      analyzer = this.fields[field].analyzer;
+    }
+
+    switch (analyzer) {
+      case 'keyword':
+        this.addTerms(doc, field);
+        break;
+      case 'standard':
+        this.addTokens(doc, field);
+        this.addTerms(doc, field);
+        break;
+      default:
+        throw new Error(`Unsupported analyzer, ${analyzer}`);
+    }
   }
 
   pipesForTokens() {

--- a/test/config/normalize.spec.js
+++ b/test/config/normalize.spec.js
@@ -1,0 +1,100 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import expect from 'expect.js';
+/* eslint-enable import/no-extraneous-dependencies */
+
+import normalize, { configValidatorMap } from '../../src/config/normalize';
+
+// Iterate over configValidatorMap (expected config spec), pull out
+// default values, and put into an object. This is a representation
+// 'default' configuration.
+const defaultConfig = Object.keys(configValidatorMap)
+  .reduce((newConfig, field) => {
+    const fieldConfig = configValidatorMap[field];
+
+    if (Object.prototype.hasOwnProperty.call(fieldConfig, 'default')) {
+      // eslint-disable-next-line no-param-reassign
+      newConfig[field] = fieldConfig.default;
+    }
+
+    return newConfig;
+  }, {});
+
+
+describe('config normalizer / validator', () => {
+  it('returns a config object with defult values via configValidatorMap',
+     () => {
+       expect(normalize({})).to.eql(defaultConfig);
+     },
+  );
+
+  it('merges passed in config with default config', () => {
+    const myConfig = {
+      stopwords: true,
+    };
+
+    const expected = Object.assign({}, defaultConfig, { stopwords: true });
+
+    expect(normalize(myConfig)).to.eql(expected);
+  });
+
+  it('merges passed in config with default config', () => {
+    const fields = {
+      name:        null,
+      description: {
+        boost:    1,
+        analyzer: 'standard',
+      },
+    };
+
+    const myConfig = {
+      fields,
+    };
+
+    const expected = Object.assign({}, defaultConfig, { fields });
+
+    expect(normalize(myConfig)).to.eql(expected);
+  });
+
+  it('throws if an invalid config option is given', () => {
+    const fields = {
+      description: {
+        boost:    1,
+        analyzer: 'unsupported',
+      },
+    };
+
+    const myConfig = {
+      fields,
+    };
+
+    expect(() => {
+      normalize(myConfig);
+    }).to.throwError();
+  });
+
+  it('throws if an invalid config option is given', () => {
+    const fields = {
+      description: {
+        boost: 'BOOST!!',
+      },
+    };
+
+    const myConfig = {
+      fields,
+    };
+
+    expect(() => {
+      normalize(myConfig);
+    }).to.throwError();
+  });
+
+  it('throws if an invalid config option is given', () => {
+    const myConfig = {
+      stopwords: 'MATT DAMON',
+    };
+
+    expect(() => {
+      normalize(myConfig);
+    }).to.throwError();
+  });
+});

--- a/test/config/normalize.spec.js
+++ b/test/config/normalize.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import expect from 'expect.js';
-/* eslint-enable import/no-extraneous-dependencies */
 
 import normalize, { configValidatorMap } from '../../src/config/normalize';
 

--- a/test/config/validators/bool.spec.js
+++ b/test/config/validators/bool.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import expect from 'expect.js';
-/* eslint-enable import/no-extraneous-dependencies */
 import bool from '../../../src/config/validators/bool';
 
 describe('bool validator', () => {

--- a/test/config/validators/bool.spec.js
+++ b/test/config/validators/bool.spec.js
@@ -1,0 +1,38 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import expect from 'expect.js';
+/* eslint-enable import/no-extraneous-dependencies */
+import bool from '../../../src/config/validators/bool';
+
+describe('bool validator', () => {
+  it('returns true for boolean values', () => {
+    expect(bool(true)).to.be(true);
+  });
+
+  it('returns true for boolean values', () => {
+    expect(bool(false)).to.be(true);
+  });
+
+  it('returns false for string values', () => {
+    expect(bool('test')).to.be(false);
+  });
+
+  it('returns false for number values', () => {
+    expect(bool(5)).to.be(false);
+  });
+
+  it('returns false for null values', () => {
+    expect(bool(null)).to.be(false);
+  });
+
+  it('returns false for undefined values', () => {
+    expect(bool(undefined)).to.be(false);
+  });
+
+  it('returns false for object values', () => {
+    expect(bool({})).to.be(false);
+  });
+
+  it('returns false for array values', () => {
+    expect(bool([])).to.be(false);
+  });
+});

--- a/test/config/validators/number.spec.js
+++ b/test/config/validators/number.spec.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import expect from 'expect.js';
+/* eslint-enable import/no-extraneous-dependencies */
+import number from '../../../src/config/validators/number';
+
+describe('number validator', () => {
+  it('returns true given number values', () => {
+    expect(number(1)).to.be(true);
+  });
+
+  it('returns true given float values', () => {
+    expect(number(1.38)).to.be(true);
+  });
+
+  it('returns false given string values', () => {
+    expect(number('1')).to.be(false);
+  });
+
+  it('returns false given null values', () => {
+    expect(number(null)).to.be(false);
+  });
+
+  it('returns false given undefined values', () => {
+    expect(number(undefined)).to.be(false);
+  });
+
+  it('returns false given object values', () => {
+    expect(number({})).to.be(false);
+  });
+
+  it('returns false given array values', () => {
+    expect(number([])).to.be(false);
+  });
+});

--- a/test/config/validators/number.spec.js
+++ b/test/config/validators/number.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import expect from 'expect.js';
-/* eslint-enable import/no-extraneous-dependencies */
 import number from '../../../src/config/validators/number';
 
 describe('number validator', () => {

--- a/test/config/validators/oneOf.spec.js
+++ b/test/config/validators/oneOf.spec.js
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import expect from 'expect.js';
+/* eslint-enable import/no-extraneous-dependencies */
+import oneOf from '../../../src/config/validators/oneOf';
+import bool from '../../../src/config/validators/bool';
+import number from '../../../src/config/validators/number';
+
+describe('oneOf validator', () => {
+  it('throws an exception if an array is not given', () => {
+    expect(() => oneOf(1)).to.throwError();
+  });
+
+  it('throws an exception if an array is not given', () => {
+    expect(() => oneOf({ test: 'test' })).to.throwError();
+  });
+
+  it('returns true if one of the values exists in the given config array',
+     () => {
+       expect(oneOf([1, 2])(1)).to.be(true);
+     });
+
+  it(
+    'returns false if one of the values doesnt exist in the given config array',
+    () => {
+      expect(oneOf([1, 2])(5)).to.be(false);
+    });
+
+  it('handles other validators', () => {
+    expect(oneOf([bool, number])(5)).to.be(true);
+  });
+
+  it('handles other validators', () => {
+    expect(oneOf([bool, number])(false)).to.be(true);
+  });
+});

--- a/test/config/validators/oneOf.spec.js
+++ b/test/config/validators/oneOf.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import expect from 'expect.js';
-/* eslint-enable import/no-extraneous-dependencies */
 import oneOf from '../../../src/config/validators/oneOf';
 import bool from '../../../src/config/validators/bool';
 import number from '../../../src/config/validators/number';

--- a/test/config/validators/shape.spec.js
+++ b/test/config/validators/shape.spec.js
@@ -1,0 +1,97 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import expect from 'expect.js';
+/* eslint-enable import/no-extraneous-dependencies */
+import Validators from '../../../src/config/validators';
+
+describe('shape validator', () => {
+  it('returns true when one field passes', () => {
+    const v = Validators.shape({
+      test: Validators.number,
+    });
+
+    expect(v({ test: 1 })).to.be(true);
+  });
+
+  it('returns false when one field fails', () => {
+    const v = Validators.shape({
+      test: Validators.number,
+    });
+
+    expect(v({ test: '1' })).to.be(false);
+  });
+
+  it('returns true when all values pass', () => {
+    const v = Validators.shape({
+      test:    Validators.number,
+      enabled: Validators.bool,
+    });
+
+    expect(v({ test: 1, enabled: true })).to.be(true);
+  });
+
+  it('returns false when one value fails', () => {
+    const v = Validators.shape({
+      test:    Validators.number,
+      enabled: Validators.bool,
+    });
+
+    expect(v({ test: 1, enabled: null })).to.be(false);
+  });
+
+  it('ignores nonexistent values', () => {
+    const v = Validators.shape({
+      test:    Validators.number,
+      enabled: Validators.bool,
+    });
+
+    expect(v({ test: 1 })).to.be(true);
+  });
+
+  it('applies validators over maps', () => {
+    const v = Validators.shape({
+      '*': Validators.number,
+    });
+
+    expect(v({ test: 1, test2: 2, test3: 3 })).to.be(true);
+  });
+
+  it('applies validators over maps', () => {
+    const v = Validators.shape({
+      '*': Validators.number,
+    });
+
+    expect(v({ test: 1, test2: 2, test3: 'string' })).to.be(false);
+  });
+
+  it('handles nested maps', () => {
+    const v = Validators.shape({
+      '*': Validators.shape({
+        boost:    Validators.number,
+        analyzer: Validators.oneOf(['standard', 'keyword']),
+      }),
+    });
+
+    expect(v({
+      name: {
+        boost:    1,
+        analyzer: 'standard',
+      },
+    })).to.be(true);
+  });
+
+  it('handles nested maps', () => {
+    const v = Validators.shape({
+      '*': Validators.shape({
+        boost:    Validators.number,
+        analyzer: Validators.oneOf(['standard', 'keyword']),
+      }),
+    });
+
+    expect(v({
+      name: {
+        boost:    1,
+        analyzer: 'UNSUPPORTED',
+      },
+    })).to.be(false);
+  });
+});

--- a/test/config/validators/shape.spec.js
+++ b/test/config/validators/shape.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import expect from 'expect.js';
-/* eslint-enable import/no-extraneous-dependencies */
 import Validators from '../../../src/config/validators';
 
 describe('shape validator', () => {

--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -358,7 +358,7 @@ describe('.search()', () => {
       });
     });
 
-    context('given a term matching a "keyword" field', () => {
+    context('given a filter term matching a "keyword" field', () => {
       const results = idx.search({
         must: {
           match: {
@@ -372,8 +372,48 @@ describe('.search()', () => {
         ],
       });
 
-      it('returns result with matching keyword', () => {
+      it('returns results filtered by keyword', () => {
         expect(results.length).to.be(2);
+      });
+    });
+
+    context('given a term exact matching a "keyword" field', () => {
+      const results = idx.search({
+        must: {
+          match: {
+            title: 'sale',
+          },
+          term: {
+            status: {
+              value: 'NEW',
+              boost: 3,
+            },
+          },
+        },
+      });
+
+      it('returns results in expected order', () => {
+        expect(searchIds(results)).to.eql([1, 3, 2]);
+      });
+    });
+
+    context('given a term with a partial "keyword" field', () => {
+      const results = idx.search({
+        must: {
+          match: {
+            title: 'sale',
+          },
+          term: {
+            status: {
+              value: 'ne',
+              boost: 3,
+            },
+          },
+        },
+      });
+
+      it('Doesnt have any effect on the ordering of results', () => {
+        expect(searchIds(results)).to.eql([1, 2, 3]);
       });
     });
   });

--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import expect from 'expect.js';
-/* eslint-enable import/no-extraneous-dependencies */
 import ESjs from '../src';
 import serializedIndex from './fixtures/serialized-index.json';
 import indexedDocs from './fixtures/indexed-docs.json';

--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -79,20 +79,8 @@ describe('.new()', () => {
     });
   });
 
-  context('given an unsupported analyzer', () => {
-    const idx = new ESjs({ fields: { name: { analyzer: 'unsupported' } } });
-
-    it('throws an exception upon indexing doc', () => {
-      expect(() => {
-        idx.addDoc({
-          name: 'bob',
-        });
-      }).to.throwError();
-    });
-  });
-
   context('given a seralized index', () => {
-    const idx = new ESjs(null, JSON.stringify(serializedIndex));
+    const idx = new ESjs({}, JSON.stringify(serializedIndex));
     const json = JSON.parse(idx.serialize());
 
     it('loads the fields', () => {
@@ -112,7 +100,7 @@ describe('.new()', () => {
     it('throws an error', () => {
       expect(() => {
         /* eslint-disable no-new */
-        new ESjs(null, JSON.stringify({ version: '0.0' }));
+        new ESjs({}, JSON.stringify({ version: '0.0' }));
         /* eslint-enable no-new */
       }).to.throwError("Error: Can't deserialize from version 0.0");
     });


### PR DESCRIPTION
This adds the ability to specify a custom `analyzer` per field.

Inspired by [elasticsearch analyzers configuration](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html) and [elasticsearch keyword analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-keyword-analyzer.html).

This will be particularly useful in context of local search within a client. Relationship fields (e.g. `widget_id` which stores, say, a UUID that points to a widget record) can be configured as `keyword` fields, in which case they won't be searchable through text search, but will be explicitly filterable through term filters. 

Example usage:
```javascript
import ESjs from 'esjs';

const fields = {
  name:        { boost: 2 },
  description: { boost: 1 },
  job:         null,
  status:      { analyzer: 'keyword' },
};

const idx = new ESjs({ fields });

idx.addDoc({
  id: 1,
  name: 'Larry Jones',
  description: 'A nice guy',
  job: 'plumber',
  status: 'AVAILABLE',
});

idx.addDoc({
  id: 2,
  name: 'Moe Jones',
  description: "Larry's brother, a decent guy",
  job: 'architect',
  status: 'AVAILABLE',
});

idx.addDoc({
  id: 3,
  name: 'Curly Jones',
  description: "Moe's brother, a funny guy",
  job: 'mathematician',
  status: 'UNAVAILABLE',
});

// Will filter by items with status `AVAILABLE`
idx.search({
  must: {
    match: {
      name: 'Jones',
    },
  },
  filter: [{
    term: { status: 'AVAILABLE' }, 
  }],
});
// [{ id: 1, score: 0.1 }, { id: 2, score: 0.1 }]

// Will not add `keyword` fields to text index
idx.search('AVAILABLE');
// []
```