### PR TITLE
speedup indexing and removing by skipping dupes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "webpack": "^2.3.2"
   },
   "dependencies": {
+    "json-stable-stringify": "1.0.1",
     "porter-stemmer": "^0.9.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,9 +2156,9 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://rival.jfrog.io/rival/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.1:
+json-stable-stringify@1.0.1, json-stable-stringify@^1.0.1:
   version "1.0.1"
-  resolved "https://rival.jfrog.io/rival/api/npm/npm/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  resolved "https://rival.jfrog.io/rival/api/npm/npm/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz?dl=https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
 


### PR DESCRIPTION
As I mentioned earlier it looks like the last esjs change caused some slowdowns due to reprocessing the same documents over and over.  I'm throwing this PR out here to get some feedback, I'm trying to hash the documents using a consistent json stringify library, but right now I'm not actually hashing, not sure what the best library to do that would be, I know @zach-10e you mentioned some crypto or hashing libraries you were using or looking at.  Anyways, this is just a draft PR for feedback before I update tests and polish this off.