### PR TITLE
speedup removing by adding doc id to node index

### DIFF
--- a/test/esjs.spec.js
+++ b/test/esjs.spec.js
@@ -221,6 +221,8 @@ describe('.removeDoc()', () => {
       idx.addDoc({ id: 1, name: 'old' });
       idx.removeDoc(1);
       expect(idx.docCount()).to.eql(0);
+      expect(Object.keys(idx.docs).length).to.eql(0);
+      expect(Object.keys(idx.docIdToIndexNodeMap).length).to.eql(0);
     });
   });
 });


### PR DESCRIPTION
This is my 2nd attempt at improving performance, in my testing it works beautifully.  We now maintain a dictionary of document ids pointing to a list of nodes, this makes it quick to unhook the document from the index nodes (instead of having to traverse the entire index tree).